### PR TITLE
Fix Microzed ethernet device tree config

### DIFF
--- a/recipes-bsp/device-tree/files/microzed/microzed-zynq7.dts
+++ b/recipes-bsp/device-tree/files/microzed/microzed-zynq7.dts
@@ -31,13 +31,6 @@
 &gem0 {
 	status = "okay";
 	phy-mode = "rgmii-id";
-	phy-handle = <&ethernet_phy>;
-
-	ethernet_phy: ethernet-phy@0 {
-		compatible = "marvell,88e1512";
-		device_type = "ethernet-phy";
-		reg = <0>;
-	};
 };
 
 &sdhci0 {


### PR DESCRIPTION
I found this fix at [Henry Feng's fork](https://github.com/HenryFeng2016/meta-xilinx/commit/348b1fe180ae778b396d50b016518614acae061e#diff-2aa239ca91226fa9beaba378085b474c) after I noticed that upgrading my yocto project to the morty branch caused the ethernet to stop working with the error `macb e000b000.ethernet eth0: no PHY found`.  Adding this change fixed it and now the Microzed's ethernet works.